### PR TITLE
Wallers and Towers

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@
 import { Builder } from "./roles/builder";
 import { Harvester } from "./roles/harvester";
 import { Upgrader } from "./roles/upgrader";
+import { Waller } from "./roles/waller";
 
 declare global {
   interface CreepMemory {
@@ -23,6 +24,7 @@ export const loop = () => {
   const harvesters = _.filter(Game.creeps, (creep) => creep.memory.role === "harvester");
   const builders = _.filter(Game.creeps, (creep) => creep.memory.role === "builder");
   const upgraders = _.filter(Game.creeps, (creep) => creep.memory.role === "upgrader");
+  const wallers = _.filter(Game.creeps, (creep) => creep.memory.role === "waller");
 
   if (harvesters.length < 4) {
     const newName = "Harvester" + Game.time;
@@ -42,6 +44,12 @@ export const loop = () => {
     Game.spawns.Spawn1.spawnCreep(
       [CARRY, CARRY, WORK, WORK, MOVE, MOVE],
       newName, {memory: {role: "upgrader"} as CreepMemory});
+  } else if (wallers.length < 2) {
+    const newName = "Waller" + Game.time;
+    console.log("Spawning new waller: " + newName);
+    Game.spawns.Spawn1.spawnCreep(
+      [CARRY, CARRY, WORK, WORK, MOVE, MOVE],
+      newName, {memory: {role: "waller"} as CreepMemory});
   }
 
   for (const name in Game.creeps) {
@@ -52,6 +60,8 @@ export const loop = () => {
       Builder.run(creep);
     } else if (creep.memory.role === "upgrader") {
       Upgrader.run(creep);
+    } else if (creep.memory.role === "waller") {
+      Waller.run(creep);
     }
   }
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@
 import { Attacker } from "./roles/attacker";
 import { Builder } from "./roles/builder";
 import { Harvester } from "./roles/harvester";
+import { Tower } from "./roles/tower";
 import { Upgrader } from "./roles/upgrader";
 import { Waller } from "./roles/waller";
 
@@ -20,6 +21,15 @@ export const loop = () => {
     if (!(name in Game.creeps)) {
       delete Memory.creeps[name];
     }
+  }
+
+  const towers = _.filter(
+    Game.structures, (structure) =>
+      structure.structureType === STRUCTURE_TOWER
+  ) as StructureTower[];
+
+  for (const tower of towers) {
+    Tower.run(tower);
   }
 
   const harvesters = _.filter(Game.creeps, (creep) => creep.memory.role === "harvester");

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 // Copyright (c) 2018 Tim Perkins
 
+import { Attacker } from "./roles/attacker";
 import { Builder } from "./roles/builder";
 import { Harvester } from "./roles/harvester";
 import { Upgrader } from "./roles/upgrader";
@@ -25,6 +26,7 @@ export const loop = () => {
   const builders = _.filter(Game.creeps, (creep) => creep.memory.role === "builder");
   const upgraders = _.filter(Game.creeps, (creep) => creep.memory.role === "upgrader");
   const wallers = _.filter(Game.creeps, (creep) => creep.memory.role === "waller");
+  const attackers = _.filter(Game.creeps, (creep) => creep.memory.role === "attacker");
 
   if (harvesters.length < 4) {
     const newName = "Harvester" + Game.time;
@@ -50,6 +52,12 @@ export const loop = () => {
     Game.spawns.Spawn1.spawnCreep(
       [CARRY, CARRY, WORK, WORK, MOVE, MOVE],
       newName, {memory: {role: "waller"} as CreepMemory});
+  } else if (attackers.length < 6) {
+    const newName = "Attacker" + Game.time;
+    console.log("Spawning new attacker: " + newName);
+    Game.spawns.Spawn1.spawnCreep(
+      [ATTACK, ATTACK, ATTACK, MOVE, MOVE, MOVE],
+      newName, {memory: {role: "attacker", flagId: "AttackFlag"} as CreepMemory});
   }
 
   for (const name in Game.creeps) {
@@ -62,6 +70,8 @@ export const loop = () => {
       Upgrader.run(creep);
     } else if (creep.memory.role === "waller") {
       Waller.run(creep);
+    } else if (creep.memory.role === "attacker") {
+      Attacker.run(creep);
     }
   }
 };

--- a/src/roles/attacker.ts
+++ b/src/roles/attacker.ts
@@ -1,0 +1,45 @@
+// Copyright (c) 2018 Tim Perkins
+
+declare global {
+  interface CreepMemory {
+    flagId: string;
+  }
+}
+
+export class Attacker {
+  public static NEARBY_ATTACK_RANGE = 5;
+
+  public static run(creep: Creep): void {
+    const flag = Game.flags[creep.memory.flagId];
+    // Always attack nearby hostiles
+    const closestHostile = creep.pos.findClosestByRange(FIND_HOSTILE_CREEPS);
+    if (closestHostile && creep.pos.inRangeTo(closestHostile, Attacker.NEARBY_ATTACK_RANGE)) {
+      if (creep.attack(closestHostile) === ERR_NOT_IN_RANGE) {
+        creep.moveTo(closestHostile);
+      }
+    } else if (flag) {
+      if (creep.room === flag.room) {
+        // Attack creeps in the room
+        const closestHostile = creep.pos.findClosestByRange(FIND_HOSTILE_CREEPS);
+        if (closestHostile) {
+          if (creep.attack(closestHostile) === ERR_NOT_IN_RANGE) {
+            creep.moveTo(closestHostile);
+          }
+        } else {
+          const closestStructure = creep.pos.findClosestByRange(FIND_HOSTILE_STRUCTURES);
+          if (closestStructure) {
+            if (creep.attack(closestStructure) === ERR_NOT_IN_RANGE) {
+              creep.moveTo(closestStructure);
+            }
+          } else {
+            // Move to the flag if the room is clear
+            creep.moveTo(flag);
+          }
+        }
+      } else {
+        // Move to the room
+        creep.moveTo(flag);
+      }
+    }
+  }
+}

--- a/src/roles/builder.ts
+++ b/src/roles/builder.ts
@@ -16,10 +16,10 @@ export class Builder {
       creep.say("Build");
     }
     if (creep.memory.building) {
-      const targets = creep.room.find(FIND_CONSTRUCTION_SITES);
-      if (targets.length) {
-        if (creep.build(targets[0]) === ERR_NOT_IN_RANGE) {
-          creep.moveTo(targets[0], {visualizePathStyle: {stroke: "#ffffff"}});
+      const sites = creep.room.find(FIND_CONSTRUCTION_SITES);
+      if (sites.length) {
+        if (creep.build(sites[0]) === ERR_NOT_IN_RANGE) {
+          creep.moveTo(sites[0], {visualizePathStyle: {stroke: "#ffffff"}});
         }
       }
     } else {

--- a/src/roles/harvester.ts
+++ b/src/roles/harvester.ts
@@ -8,17 +8,16 @@ export class Harvester {
         creep.moveTo(sources[1], {visualizePathStyle: {stroke: "#ffaa00"}});
       }
     } else {
-      const targets = creep.room.find(FIND_STRUCTURES, {
-        filter: (structure) => {
-          return ((structure.structureType === STRUCTURE_EXTENSION ||
-                   structure.structureType === STRUCTURE_SPAWN ||
-                   structure.structureType === STRUCTURE_TOWER)
-                  && structure.energy < structure.energyCapacity);
-        }
+      const consumers = creep.room.find(FIND_STRUCTURES, {
+        filter: (structure) =>
+          ((structure.structureType === STRUCTURE_EXTENSION
+            || structure.structureType === STRUCTURE_SPAWN
+            || structure.structureType === STRUCTURE_TOWER)
+           && structure.energy < structure.energyCapacity)
       });
-      if (targets.length) {
-        if (creep.transfer(targets[0], RESOURCE_ENERGY) === ERR_NOT_IN_RANGE) {
-          creep.moveTo(targets[0], {visualizePathStyle: {stroke: "#ffffff"}});
+      if (consumers.length) {
+        if (creep.transfer(consumers[0], RESOURCE_ENERGY) === ERR_NOT_IN_RANGE) {
+          creep.moveTo(consumers[0], {visualizePathStyle: {stroke: "#ffffff"}});
         }
       }
     }

--- a/src/roles/harvester.ts
+++ b/src/roles/harvester.ts
@@ -1,13 +1,21 @@
 // Copyright (c) 2018 Tim Perkins
 
+declare global {
+  interface CreepMemory {
+    harvesting: boolean;
+  }
+}
+
 export class Harvester {
   public static run(creep: Creep): void {
-    if (creep.carry.energy < creep.carryCapacity) {
-      const sources = creep.room.find(FIND_SOURCES);
-      if (creep.harvest(sources[1]) === ERR_NOT_IN_RANGE) {
-        creep.moveTo(sources[1], {visualizePathStyle: {stroke: "#ffaa00"}});
-      }
-    } else {
+    if (!creep.memory.harvesting && creep.carry.energy === 0) {
+      creep.memory.harvesting = true;
+      creep.say("Harvest");
+    } else if (creep.memory.upgrading && creep.carry.energy === creep.carryCapacity) {
+      creep.memory.harvesting = false;
+      creep.say("Deposit");
+    }
+    if (!creep.memory.harvesting) {
       const consumers = creep.room.find(FIND_STRUCTURES, {
         filter: (structure) =>
           ((structure.structureType === STRUCTURE_EXTENSION
@@ -19,6 +27,11 @@ export class Harvester {
         if (creep.transfer(consumers[0], RESOURCE_ENERGY) === ERR_NOT_IN_RANGE) {
           creep.moveTo(consumers[0], {visualizePathStyle: {stroke: "#ffffff"}});
         }
+      }
+    } else {
+      const sources = creep.room.find(FIND_SOURCES);
+      if (creep.harvest(sources[1]) === ERR_NOT_IN_RANGE) {
+        creep.moveTo(sources[1], {visualizePathStyle: {stroke: "#ffaa00"}});
       }
     }
   }

--- a/src/roles/tower.ts
+++ b/src/roles/tower.ts
@@ -1,0 +1,21 @@
+// Copyright (c) 2018 Tim Perkins
+
+export class Tower {
+  public static RESERVE_ENERGY = 500;
+
+  public static run(tower: StructureTower): void {
+    const closestHostile = tower.pos.findClosestByRange(FIND_HOSTILE_CREEPS);
+    if (closestHostile) {
+      tower.attack(closestHostile);
+    } else if (tower.energy > Tower.RESERVE_ENERGY) {
+      // Only repair if we have enough energy to attack
+      const closestDamagedStructure = tower.pos.findClosestByRange(FIND_STRUCTURES, {
+        filter: (structure) =>
+          structure.structureType !== STRUCTURE_WALL && structure.hits < structure.hitsMax
+      });
+      if (closestDamagedStructure) {
+        tower.repair(closestDamagedStructure);
+      }
+    }
+  }
+}

--- a/src/roles/waller.ts
+++ b/src/roles/waller.ts
@@ -1,0 +1,54 @@
+// Copyright (c) 2018 Tim Perkins
+
+declare global {
+  interface CreepMemory {
+    walling: boolean;
+  }
+}
+
+export class Waller {
+  public static WALL_GROUP_HITS = [1000, 5000, 10000, 50000, 100000];
+  public static WALL_MAX_HITS = _.last(Waller.WALL_GROUP_HITS);
+
+  public static run(creep: Creep): void {
+    if (creep.memory.walling && creep.carry.energy === 0) {
+      creep.memory.walling = false;
+      creep.say("Harvest");
+    } else if (!creep.memory.walling && creep.carry.energy === creep.carryCapacity) {
+      creep.memory.walling = true;
+      creep.say("Walling");
+    }
+    if (creep.memory.walling) {
+      const wallSites = creep.room.find(FIND_CONSTRUCTION_SITES, {
+        filter: (structure) => structure.structureType === STRUCTURE_WALL
+      });
+      if (wallSites.length) {
+        if (creep.build(wallSites[0]) === ERR_NOT_IN_RANGE) {
+          creep.moveTo(wallSites[0], {visualizePathStyle: {stroke: "#ffffff"}});
+        }
+      } else {
+        const walls = creep.room.find(FIND_STRUCTURES, {
+          filter: (structure) =>
+            (structure.structureType === STRUCTURE_WALL
+             && structure.hits < Waller.WALL_MAX_HITS)
+        });
+        const wallGroups = _.groupBy(walls, (wall) => {
+          return _.find(Waller.WALL_GROUP_HITS, (groupHits) => wall.hits < groupHits);
+        });
+        const lowestGroupHits = _.find(
+          Waller.WALL_GROUP_HITS, (groupHits) => groupHits in wallGroups);
+        const wall = lowestGroupHits ? wallGroups[lowestGroupHits][0] : null;
+        if (wall) {
+          if (creep.repair(wall) === ERR_NOT_IN_RANGE) {
+            creep.moveTo(wall, {visualizePathStyle: {stroke: "#ffffff"}});
+          }
+        }
+      }
+    } else {
+      const sources = creep.room.find(FIND_SOURCES);
+      if (creep.harvest(sources[1]) === ERR_NOT_IN_RANGE) {
+        creep.moveTo(sources[1], {visualizePathStyle: {stroke: "#ffaa00"}});
+      }
+    }
+  }
+}

--- a/tslint.json
+++ b/tslint.json
@@ -31,6 +31,9 @@
       "check-format",
       "allow-pascal-case",
       "allow-leading-underscore"
+    ],
+    "no-shadowed-variable": [
+      false
     ]
   }
 }


### PR DESCRIPTION
Adds some more roles, such as wallers, attackers, and towers.

Wallers work by upgrading walls in tiers. They will first upgrade all walls to the lowest hit threshold, then once all the walls are above that threshold it will begin upgrading all walls to the next threshold, and so on. By doing this, all walls should be built up relatively evenly. (The downside is that you can't prioritize one wall over another.)

Attackers operate by moving to flags and attacking everything in the room. The flags must be moved around manually.

The tower script is very simple and just attacks all the hostile creeps in the room. It will also repair structures, e.g., roads, if it has enough energy in reserve.