### PR TITLE
Withdraw from storage

### DIFF
--- a/src/creeps/builder.ts
+++ b/src/creeps/builder.ts
@@ -8,7 +8,7 @@ import {MoveFromMinerSource, MoveFromSource} from "./tasks/movefromsource";
 import {MoveToFlagRoom} from "./tasks/movetoflag";
 import {Pickup} from "./tasks/pickup";
 import {Upgrade} from "./tasks/upgrade";
-import {Withdraw} from "./tasks/withdraw";
+import {WithdrawFromContainer, WithdrawFromStorage} from "./tasks/withdraw";
 import * as Utils from "./utils";
 
 export class Builder {
@@ -47,7 +47,8 @@ export class Builder {
         GraveDig,
         Pickup,
         MoveFromMinerSource,
-        Withdraw,
+        WithdrawFromContainer,
+        WithdrawFromStorage,
         Harvest,
       ]);
     }

--- a/src/creeps/harvester.ts
+++ b/src/creeps/harvester.ts
@@ -8,7 +8,7 @@ import {MoveFromMinerSource, MoveFromSource} from "./tasks/movefromsource";
 import {Pickup} from "./tasks/pickup";
 import {StoreInStorage} from "./tasks/store";
 import {Upgrade} from "./tasks/upgrade";
-import {Withdraw} from "./tasks/withdraw";
+import {WithdrawFromContainer, WithdrawFromStorage} from "./tasks/withdraw";
 import * as Utils from "./utils";
 
 export class Harvester {
@@ -46,7 +46,8 @@ export class Harvester {
         GraveDig,
         Pickup,
         MoveFromMinerSource,
-        Withdraw,
+        WithdrawFromContainer,
+        WithdrawFromStorage,
         Harvest,
       ]);
     }

--- a/src/creeps/tasks/withdraw.ts
+++ b/src/creeps/tasks/withdraw.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2018 Tim Perkins
 
-export class Withdraw {
+export class WithdrawFromContainer {
   public static FAR_DISTANCE_THRESHOLD = 5;
   public static FAR_ENERGY_THRESHOLD = 500;
 
@@ -14,6 +14,30 @@ export class Withdraw {
     if (container) {
       if (creep.withdraw(container, RESOURCE_ENERGY) === ERR_NOT_IN_RANGE) {
         creep.moveTo(container, {visualizePathStyle: {stroke: "#ffaa00"}});
+      }
+      return true;
+    } else {
+      return false;
+    }
+  }
+}
+
+/**
+ * This behavior should be used as a fallback. Like when the containers are empty.
+ *
+ * TODO This could be problematic. For example, a creep might get stuck in a loop withdrawing from
+ * storage, when the only task it has left to do is fill the storage.
+ */
+export class WithdrawFromStorage {
+  public static run(creep: Creep): boolean {
+    const storages = creep.room.find(FIND_STRUCTURES, {
+      filter: (structure) => (structure.structureType === STRUCTURE_STORAGE
+                              && structure.store.energy > 0.5 * structure.storeCapacity),
+    });
+    if (storages.length) {
+      const storage = storages[0];
+      if (creep.withdraw(storage, RESOURCE_ENERGY) === ERR_NOT_IN_RANGE) {
+        creep.moveTo(storage, {visualizePathStyle: {stroke: "#ffaa00"}});
       }
       return true;
     } else {

--- a/src/creeps/upgrader.ts
+++ b/src/creeps/upgrader.ts
@@ -5,7 +5,7 @@ import {Harvest} from "./tasks/harvest";
 import {MoveFromMinerSource, MoveFromSource} from "./tasks/movefromsource";
 import {Pickup} from "./tasks/pickup";
 import {Upgrade} from "./tasks/upgrade";
-import {Withdraw} from "./tasks/withdraw";
+import {WithdrawFromContainer} from "./tasks/withdraw";
 import * as Utils from "./utils";
 
 export class Upgrader {
@@ -40,7 +40,7 @@ export class Upgrader {
         GraveDig,
         Pickup,
         MoveFromMinerSource,
-        Withdraw,
+        WithdrawFromContainer,
         Harvest,
       ]);
     }

--- a/src/creeps/waller.ts
+++ b/src/creeps/waller.ts
@@ -9,7 +9,7 @@ import {Pickup} from "./tasks/pickup";
 import {Return} from "./tasks/return";
 import {Upgrade} from "./tasks/upgrade";
 import {Wall} from "./tasks/wall";
-import {Withdraw} from "./tasks/withdraw";
+import {WithdrawFromContainer, WithdrawFromStorage} from "./tasks/withdraw";
 import * as Utils from "./utils";
 
 export class Waller {
@@ -48,7 +48,8 @@ export class Waller {
         GraveDig,
         Pickup,
         MoveFromMinerSource,
-        Withdraw,
+        WithdrawFromContainer,
+        WithdrawFromStorage,
         Harvest,
       ]);
     }


### PR DESCRIPTION
Quick and dirty withdraw from storage. It works, but there is also nothing to stop a creep from withdrawing from storage and then immediately depositing back into storage. This isn't ideal, but it should be pretty much benign.