### PR TITLE
Overhaul of Claimer/Reserver code

### DIFF
--- a/src/colonies/colony.ts
+++ b/src/colonies/colony.ts
@@ -7,6 +7,7 @@ import {Builder} from "../creeps/builder";
 import {Claimer} from "../creeps/claimer";
 import {Harvester} from "../creeps/harvester";
 import {Miner} from "../creeps/miner";
+import {Reserver} from "../creeps/reserver";
 import {Upgrader} from "../creeps/upgrader";
 import {Waller} from "../creeps/waller";
 import {Tower} from "../towers/tower";
@@ -33,6 +34,7 @@ export class Colony {
     [Waller.ROLE_NAME]: Waller,
     [Attacker.ROLE_NAME]: Attacker,
     [Claimer.ROLE_NAME]: Claimer,
+    [Reserver.ROLE_NAME]: Reserver,
   };
 
   private static readonly _SPAWN_ORDER: string[] = [
@@ -43,6 +45,7 @@ export class Colony {
     Waller.ROLE_NAME,
     Attacker.ROLE_NAME,
     Claimer.ROLE_NAME,
+    Reserver.ROLE_NAME,
   ];
 
   private static readonly _DEFAULT_POPULATIONS: Utils.RolePopulations = {
@@ -53,7 +56,8 @@ export class Colony {
     [Upgrader.ROLE_NAME]: {population: 1},
     [Waller.ROLE_NAME]: {population: 2},
     [Attacker.ROLE_NAME]: {population: 2},
-    [Claimer.ROLE_NAME]: {population: 1, atLevel: 3},
+    [Claimer.ROLE_NAME]: {population: 0, atLevel: 3},
+    [Reserver.ROLE_NAME]: {population: 1, atLevel: 3},
   };
 
   private static readonly _ENERGY_CAPS: {[roleName: string]: number} = {
@@ -155,6 +159,7 @@ export class Colony {
     // TODO HACK Only spawn claimer in my main room
     if (room.name !== "E52S56") {
       targetPopulations[Claimer.ROLE_NAME].population = 0;
+      targetPopulations[Reserver.ROLE_NAME].population = 0;
     }
     // Get the actual population for each role
     const actualPopulations = (() => {
@@ -203,6 +208,8 @@ export class Colony {
           memory.attackFlagName = "AttackFlag";
         } else if (role === Claimer) {
           memory.claimFlagName = "ClaimFlag";
+        } else if (role === Reserver) {
+          memory.reserveFlagNames = ["ReserveFlag1", "ReserveFlag2", "ReserveFlag3"];
         }
         // Actually try to spawn the creep
         console.log(C(room) + "Wants to spawn: " + name);

--- a/src/creeps/builder.ts
+++ b/src/creeps/builder.ts
@@ -22,6 +22,11 @@ export class Builder {
   public static readonly PART_GROUPS = [Builder._PG_A];
   public static readonly REPEAT_PARTS = true;
 
+  private static readonly _WithFlag: Utils.WithFlagTask = Utils.makeWithFlagTask((creep) => {
+    const flagName = creep.memory.buildFlagName;
+    return flagName ? Game.flags[flagName] : null;
+  });
+
   public static run(creep: Creep): void {
     const fullEnergyThreshold = getOrInitialize(creep.memory, "fullEnergyThreshold", () => {
       return Utils.getNoDropEnergyThreshold(creep);
@@ -33,12 +38,11 @@ export class Builder {
       creep.memory.building = true;
       creep.say("Build");
     }
-    const flag = Game.flags[creep.memory.buildFlagName];
     if (creep.memory.building) {
       Utils.runTasks(creep, [
         MoveFromSource,
         MoveFromMinerSource,
-        MoveToFlagRoom.forFlag(flag),
+        Builder._WithFlag((flag) => MoveToFlagRoom.forFlag(flag)),
         Build,
         Deposit,
         Upgrade,

--- a/src/creeps/claimer.ts
+++ b/src/creeps/claimer.ts
@@ -1,5 +1,6 @@
 // Copyright (c) 2018 Tim Perkins
 
+import {AttackController} from "./tasks/attackcontroller";
 import {Claim} from "./tasks/claim";
 import {MoveToFlag, MoveToFlagRoom} from "./tasks/movetoflag";
 import * as Utils from "./utils";
@@ -13,12 +14,17 @@ export class Claimer {
       [Claimer._PG_A, Claimer._PG_A, Claimer._PG_A, Claimer._PG_A, Claimer._PG_A];
   public static readonly REPEAT_PARTS = false;
 
+  private static readonly _WithFlag: Utils.WithFlagTask = Utils.makeWithFlagTask((creep) => {
+    const flagName = creep.memory.claimFlagName;
+    return flagName ? Game.flags[flagName] : null;
+  });
+
   public static run(creep: Creep): void {
-    const flag = Game.flags[creep.memory.claimFlagName];
     Utils.runTasks(creep, [
-      MoveToFlagRoom.forFlag(flag),
+      Claimer._WithFlag((flag) => MoveToFlagRoom.forFlag(flag)),
+      AttackController,
       Claim,
-      MoveToFlag.forFlag(flag),
+      Claimer._WithFlag((flag) => MoveToFlag.forFlag(flag)),
     ]);
   }
 }

--- a/src/creeps/memory.d.ts
+++ b/src/creeps/memory.d.ts
@@ -24,4 +24,8 @@ declare interface CreepMemory {
 
   // Claimer memory
   claimFlagName: string;
+
+  // Reserver memory
+  reserveFlagNames: string[];
+  currentReserveFlagName: string|null;
 }

--- a/src/creeps/reserver.ts
+++ b/src/creeps/reserver.ts
@@ -1,0 +1,78 @@
+// Copyright (c) 2018 Tim Perkins
+
+import {getOrInitialize, MY_USERNAME} from "../utils/common";
+
+import {AttackController} from "./tasks/attackcontroller";
+
+import {MoveToFlag, MoveToFlagRoom} from "./tasks/movetoflag";
+import {Reserve} from "./tasks/reserve";
+import * as Utils from "./utils";
+
+export class Reserver {
+
+  public static readonly ROLE_NAME = "reserver";
+  public static readonly PART_TEMPLATE = [CLAIM, MOVE];
+  private static readonly _PG_A = [CLAIM, MOVE];
+  public static readonly PART_GROUPS =
+      [Reserver._PG_A, Reserver._PG_A, Reserver._PG_A, Reserver._PG_A, Reserver._PG_A];
+  public static readonly REPEAT_PARTS = false;
+  public static readonly MAX_RESERVATION_TICKS = 4500;
+
+  private static readonly _SelectFlag: Utils.Task = Utils.makeTask((creep) => {
+    // If there's a flag, keep the current one
+    if (creep.memory.currentReserveFlagName) {
+      return false;
+    }
+    // TODO THE **COLONY** NEEDS TO COORDINATE MULTIPLE RESERVERS
+    const flags = _.compact(
+        _.map(creep.memory.reserveFlagNames, (flagName) => Game.flags[flagName]),
+    );
+    const rooms = _.map(flags, (flag) => Game.rooms[flag.pos.roomName]);
+    const flagsAndRooms = _.zip<any>(flags, rooms) as [Flag, Room][];
+    const [flagsWithoutRooms, flagsWithRooms] =
+        _.partition(flagsAndRooms, ([_, room]) => room == null);
+    if (flagsWithoutRooms.length) {
+      // If some rooms aren't visible, go to the first one
+      const flag = flagsWithoutRooms[0][0];
+      creep.memory.currentReserveFlagName = flag.name;
+    } else if (flagsWithRooms.length) {
+      const flagsWithControllers =
+          _.filter(flagsWithRooms, ([_, room]) => room.controller && room.controller.level === 0);
+      // If some rooms are visible, go to the lowest reservation
+      const flagAndRoom = _.min(flagsWithControllers, Reserver._getReservationScore);
+      creep.memory.currentReserveFlagName = flagAndRoom[0].name;
+    }
+    return false;
+  });
+
+  private static _getReservationScore(flagAndRoom: [Flag, Room]): number {
+    const controller = flagAndRoom[1].controller;
+    if (!controller || controller.level !== 0) {
+      return Infinity;
+    } else if (controller.reservation && controller.reservation.username === MY_USERNAME) {
+      return controller.reservation.ticksToEnd;
+    } else {
+      return 0;
+    }
+  }
+
+  private static _WithFlag: Utils.WithFlagTask = Utils.makeWithFlagTask((creep) => {
+    const flagName = creep.memory.currentReserveFlagName;
+    return flagName ? Game.flags[flagName] : null;
+  });
+
+  private static readonly _ClearFlag: Utils.Task = Utils.makeTask((creep) => {
+    creep.memory.currentReserveFlagName = null;
+    return false;
+  });
+
+  public static run(creep: Creep): void {
+    Utils.runTasks(creep, [
+      Reserver._SelectFlag,
+      Reserver._WithFlag((flag) => MoveToFlagRoom.forFlag(flag)),
+      AttackController,
+      Reserve.upTo(Reserver.MAX_RESERVATION_TICKS),
+      Reserver._ClearFlag,
+    ]);
+  }
+}

--- a/src/creeps/tasks/attackcontroller.ts
+++ b/src/creeps/tasks/attackcontroller.ts
@@ -1,0 +1,22 @@
+// Copyright (c) 2018 Tim Perkins
+
+import {MY_USERNAME} from "../../utils/common";
+
+export class AttackController {
+
+  public static run(creep: Creep): boolean {
+    const controller = creep.room.controller;
+    if (!controller) {
+      return false;
+    }
+    if ((controller.level !== 0 && !controller.my)
+        || (controller.reservation && controller.reservation.username !== MY_USERNAME)) {
+      if (creep.attackController(controller) === ERR_NOT_IN_RANGE) {
+        creep.moveTo(controller, {visualizePathStyle: {stroke: "#ffffff"}});
+      }
+      return true;
+    } else {
+      return false;
+    }
+  }
+}

--- a/src/creeps/tasks/claim.ts
+++ b/src/creeps/tasks/claim.ts
@@ -1,5 +1,7 @@
 // Copyright (c) 2018 Tim Perkins
 
+import {MY_USERNAME} from "../../utils/common";
+
 export class Claim {
 
   public static run(creep: Creep): boolean {
@@ -7,12 +9,8 @@ export class Claim {
     if (!controller) {
       return false;
     }
-    if (!controller.my) {
-      if (creep.attackController(controller) === ERR_NOT_IN_RANGE) {
-        creep.moveTo(controller, {visualizePathStyle: {stroke: "#ffffff"}});
-      }
-      return true;
-    } else if (controller.level === 0) {
+    if (controller.level === 0
+        && (!controller.reservation || controller.reservation.username === MY_USERNAME)) {
       if (creep.claimController(controller) === ERR_NOT_IN_RANGE) {
         creep.moveTo(controller, {visualizePathStyle: {stroke: "#ffffff"}});
       }

--- a/src/creeps/tasks/movetoflag.ts
+++ b/src/creeps/tasks/movetoflag.ts
@@ -10,8 +10,8 @@ export class MoveToFlag {
     this._flag = flag;
   }
 
-  public static forFlag(flag: Flag|null): MoveToFlag|null {
-    return flag ? new MoveToFlag(flag) : null;
+  public static forFlag(flag: Flag): MoveToFlag {
+    return new MoveToFlag(flag);
   }
 
   public run(creep: Creep): boolean {
@@ -33,8 +33,8 @@ export class MoveToFlagRoom {
     this._flag = flag;
   }
 
-  public static forFlag(flag: Flag|null): MoveToFlagRoom|null {
-    return flag ? new MoveToFlagRoom(flag) : null;
+  public static forFlag(flag: Flag): MoveToFlagRoom {
+    return new MoveToFlagRoom(flag);
   }
 
   public run(creep: Creep): boolean {

--- a/src/creeps/tasks/reserve.ts
+++ b/src/creeps/tasks/reserve.ts
@@ -1,0 +1,34 @@
+// Copyright (c) 2018 Tim Perkins
+
+import {MY_USERNAME} from "../../utils/common";
+
+export class Reserve {
+
+  public _reserveTicks: number;
+
+  private constructor(reserveTicks: number) {
+    this._reserveTicks = reserveTicks;
+  }
+
+  public static upTo(ticks: number): Reserve {
+    return new Reserve(ticks);
+  }
+
+  public run(creep: Creep): boolean {
+    const controller = creep.room.controller;
+    if (!controller) {
+      return false;
+    }
+    if (controller.level === 0
+        && (!controller.reservation
+            || (controller.reservation.username === MY_USERNAME
+                && controller.reservation.ticksToEnd < this._reserveTicks))) {
+      if (creep.reserveController(controller) === ERR_NOT_IN_RANGE) {
+        creep.moveTo(controller, {visualizePathStyle: {stroke: "#ffffff"}});
+      }
+      return true;
+    } else {
+      return false;
+    }
+  }
+}

--- a/src/creeps/utils.ts
+++ b/src/creeps/utils.ts
@@ -14,7 +14,7 @@ export interface Role {
 /**
  * Task interface, for running tasks. See also `runTasks`.
  */
-interface Task {
+export interface Task {
   run: (creep: Creep) => boolean;
 }
 

--- a/src/creeps/utils.ts
+++ b/src/creeps/utils.ts
@@ -18,6 +18,33 @@ interface Task {
   run: (creep: Creep) => boolean;
 }
 
+export function makeTask(lambda: (creep: Creep) => boolean): Task {
+  return {
+    run(creep: Creep): boolean {
+      return lambda(creep);
+    }
+  };
+}
+
+export type FlagRetriever = (creep: Creep) => Flag|null;
+export type TaskFromFlag = (flag: Flag) => Task;
+export type WithFlagTask = (taskFromFlag: TaskFromFlag) => Task;
+
+export function makeWithFlagTask(flagRetriever: FlagRetriever): WithFlagTask {
+  return (taskFromFlag: TaskFromFlag) => {
+    return {
+      run(creep: Creep): boolean {
+        const flag = flagRetriever(creep);
+        if (flag) {
+          return taskFromFlag(flag).run(creep);
+        } else {
+          return false;
+        }
+      }
+    };
+  };
+}
+
 /**
  * Tries to tasks in order, until one is eligible to run.
  */

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,12 +14,8 @@ export function loop() {
     }
   }
   // Find all controlled and claimed rooms
-  const claimedRooms = _.filter(Game.rooms, (room) => {
-    if (room.controller) {
-      return room.controller.my && room.controller.level > 0;
-    } else {
-      return false;
-    }
+  const claimedRooms = _.filter(Game.rooms as {[roomName: string]: Room}, (room) => {
+    return room.controller && room.controller.my;
   });
   // Run the colonies, one per claimed room
   for (const room of claimedRooms) {

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -1,5 +1,12 @@
 // Copyright (c) 2018 Tim Perkins
 
+export const MY_USERNAME: string = (() => {
+  const controller = _.find(Game.structures, (structure) => {
+    return structure.structureType === STRUCTURE_CONTROLLER;
+  }) as StructureController;
+  return controller.owner.username;
+})();
+
 /**
  * Tries to get a value, or initializes it with the initializer.
  */


### PR DESCRIPTION
Adds a new reserver creep, which until now was a hack on the claimer creep. Changed the way creeps use flags in tasks, by using task wrapper and some utilities.

This is brushing up against the limits on individual creep behavior, the next step will be colony level behavior to, for example, dispatch reserver creeps.